### PR TITLE
Autorepair e2fsck errors

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -131,7 +131,7 @@ else
 fi
 
 #Make sure filesystem is ok
-e2fsck -f $loopback
+e2fsck -p -f $loopback
 minsize=`resize2fs -P $loopback | cut -d ':' -f 2 | tr -d ' ' | tr -d '\n'`
 if [[ $currentsize -eq $minsize ]]; then
   echo ERROR: Image already shrunk to smallest size


### PR DESCRIPTION
Makes sense to me to autorepair e2fsck errors. In addition option -p is mandatory if PiShrink is run in a cron job.

I first thought a new option -r would make sense to enable automatic repair but I think it's worth to autorepair all the time.

See also issue https://github.com/Drewsif/PiShrink/issues/32 which will be fixed by this PR.