### PR TITLE
Don't allow a directory to be selected

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -19,7 +19,7 @@ img="$1"
 if [[ -z "$img" ]]; then
   usage
 fi
-if [[ ! -e "$img" ]]; then
+if [[ ! -f "$img" ]]; then
   echo "ERROR: $img is not a file..."
   exit -2
 fi


### PR DESCRIPTION
The `-e` flag checks for a file _or_ a directory of that name. The `-f` flag checks only for files.