### PR TITLE
-c option to clean up image before shrinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
 PiShrink is a bash script that automatically shrink a pi image that will then resize to the max size of the SD card on boot. This will make putting the image back onto the SD card faster and the shrunk images will compress better.
 
 ## Usage ##
-`sudo pishrink.sh [-s] imagefile.img [newimagefile.img]`
+`sudo pishrink.sh [-s|-c] imagefile.img [newimagefile.img]`
 
 If the `-s` option is given the script will skip the autoexpanding part of the process.  If you specify the `newimagefile.img` parameter, the script will make a copy of `imagefile.img` and work off that. You will need enough space to make a full copy of the image to use that option.
+
+The `-c` option will clean the image up a little bit before shrinking it. Currently this will
+
+  - Remove the ssh host keys and install a script to re-generate them on first boot
+  - Remove cached debian packages from /var/cache/apt
+  - Remove old log files
+
+The `-c` option is intended to be used when preparing an image for use on a different Pi or for distribution.
 
 ## Prerequisites ##
 If you are trying to shrink a [NOOBS](https://github.com/raspberrypi/noobs) image it will likely fail. This is due to [NOOBS paritioning](https://github.com/raspberrypi/noobs/wiki/NOOBS-partitioning-explained) being significantly different than Raspian's. Hopefully PiShrink will be able to support NOOBS in the near future.


### PR DESCRIPTION
The -c option is intended to remove private information as well as cached data from the image. It's intended to be used when using the image on a different pi or when distributing the image.