### PR TITLE
Add support for expanding a bootable USB

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -82,26 +82,21 @@ if [ "$should_skip_autoexpand" = false ]; then
 cat <<\EOF1 > "$mountdir/etc/rc.local"
 #!/bin/bash
 do_expand_rootfs() {
-  ROOT_PART=$(mount | sed -n 's|^/dev/\(.*\) on / .*|\1|p')
-
-  PART_NUM=${ROOT_PART#mmcblk0p}
-  if [ "$PART_NUM" = "$ROOT_PART" ]; then
-    echo "$ROOT_PART is not an SD card. Don't know how to expand"
-    return 0
-  fi
+  ROOT_PART=$(findmnt / -o source -n)
+  ROOT_DEV=/dev/$(lsblk -no pkname $ROOT_PART)
 
   # Get the starting offset of the root partition
-  PART_START=$(parted /dev/mmcblk0 -ms unit s p | grep "^${PART_NUM}" | cut -f 2 -d: | sed 's/[^0-9]//g')
+  PART_START=$(parted $ROOT_PART -ms unit s p | grep "^${ROOT_PART}" | cut -f 2 -d: | sed 's/[^0-9]//g')
   [ "$PART_START" ] || return 1
   # Return value will likely be error for fdisk as it fails to reload the
   # partition table because the root fs is mounted
-  fdisk /dev/mmcblk0 <<EOF
+  fdisk $ROOT_DEV <<EOF
 p
 d
-$PART_NUM
+$ROOT_PART
 n
 p
-$PART_NUM
+$ROOT_PART
 $PART_START
 
 p
@@ -110,8 +105,8 @@ EOF
 
 cat <<EOF > /etc/rc.local &&
 #!/bin/sh
-echo "Expanding /dev/$ROOT_PART"
-resize2fs /dev/$ROOT_PART
+echo "Expanding $ROOT_PART"
+resize2fs $ROOT_PART
 rm -f /etc/rc.local; cp -f /etc/rc.local.bak /etc/rc.local; /etc/rc.local
 
 EOF


### PR DESCRIPTION
I changed $ROOT_PART to get its value from findmnt, which will give us /dev/sdaX in the event we are booting off of a USB. This will still work for when booting of a microSD card in the microSD card slot, as findmnt will give us /dev/mmcblk0pX.

Since I can't predict how many partitions someone might have before their root partition, I used lsblk to find the name of the root device (/dev/sda2 -> /dev/sda and /dev/mmcblk0p2 -> /dev/mmcblk0)

I've tested this out booting off USB, and off of a microSD card in the microSD card slot, and it's worked every time so far.

I did remove the  portion checking if PART_NUM == ROOT_PART, but since we can expand a bootable USB, I don't see why it's necessary. 

I believe this should fix #63