### PR TITLE
stop on parted error

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -160,7 +160,13 @@ trap cleanup ERR EXIT
 #Gather info
 info "Gathering data"
 beforesize=$(ls -lh "$img" | cut -d ' ' -f 5)
-parted_output=$(parted -ms "$img" unit B print | tail -n 1)
+if ! parted_output=$(parted -ms "$img" unit B print); then
+  rc=$?
+	error $LINENO "parted failed with rc $rc"
+  info "Possibly invalid image. Run 'parted $img unit B print' manually to investigate"
+	exit -6
+fi
+parted_output=$(echo "$parted_output" | tail -n 1)
 partnum=$(echo "$parted_output" | cut -d ':' -f 1)
 partstart=$(echo "$parted_output" | cut -d ':' -f 2 | tr -d 'B')
 loopback=$(losetup -f --show -o "$partstart" "$img")


### PR DESCRIPTION
Stop when parted can not do it's work.
One such, fixable, error is described in https://unix.stackexchange.com/questions/319922/error-cant-have-a-partition-outside-the-disk-even-though-number-of-sectors.

Relates to #29 and #50 at least