### PR TITLE
Fix log removal

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -308,7 +308,7 @@ if [[ $prep == true ]]; then
   info "Syspreping: Removing logs, apt archives, dhcp leases and ssh hostkeys"
   mountdir=$(mktemp -d)
   mount "$loopback" "$mountdir"
-  rm -rf "$mountdir/var/cache/apt/archives/*" "$mountdir/var/lib/dhcpcd5/*" "$mountdir/var/log/*" "$mountdir/var/tmp/*" "$mountdir/tmp/*" "$mountdir/etc/ssh/*_host_*"
+  rm -rvf $mountdir/var/cache/apt/archives/* $mountdir/var/lib/dhcpcd5/* $mountdir/var/log/* $mountdir/var/tmp/* $mountdir/tmp/* $mountdir/etc/ssh/*_host_*
   umount "$mountdir"
 fi
 


### PR DESCRIPTION
The line for log removal quoted the paths, which disabled the wildcard. Turns out no file will be removed. Also it may be better to make the removal verbose to let user know what are being removed.