### PR TITLE
Keep ssh config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Usage: $0 [-adhrspvzZ] imagefile.img [newimagefile.img]
   -z         Compress image after shrinking with gzip
   -Z         Compress image after shrinking with xz
   -a         Compress image in parallel using multiple cores
-  -p         Remove logs, apt archives, dhcp leases and ssh hostkeys
+  -p         Remove logs, apt archives, dhcp leases
+  -P         Remove logs, apt archives, dhcp leases and ssh hostkeys
   -d         Write debug messages in a debug log file
 ```
 
@@ -28,6 +29,8 @@ If you specify the `newimagefile.img` parameter, the script will make a copy of 
 * `-z` will compress the image after shrinking using gzip. `.gz` extension will be added to the filename.
 * `-Z` will compress the image after shrinking using xz. `.xz` extension will be added to the filename.
 * `-a` will use option -f9 for pigz and option -T0 for xz and compress in parallel.
+* `-p` will remove temp files, logs, apt archives, dhcp leases (but no longer removes hostkeys as in previous version)
+* `-P` will remove temp files, logs, apt archives, dhcp leases and hostkeys (beware: this prevents ssh login)
 * `-d` will create a logfile `pishrink.log` which may help for problem analysis.
 
 Default options for compressors can be overwritten by defining PISHRINK_GZIP or PSHRINK_XZ environment variables for gzip and xz.


### PR DESCRIPTION
The -p prepare option is very useful to reduce size of shrinked image.
Unfortunately it removes ssh host keys after which it is not possible to connect to a running image with ssh.

Removing host keys renders the shrinked image incompatible compared to the original unshriked image.
Host keys are not garbage and should not by default be removed like temp files, logs etc.

This pull request adds functionality to prepare without removing host keys.
The existing option -p is changed and will no longer remove host keys.
The new option -P prepares with removing host keys like -p did before.