### PR TITLE
Fix autoresize if no console

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -189,7 +189,7 @@ function boot_enable_console () {
   local fsroot="$1"
   local bootstart="$(echo "$parted_output" | grep '^1:' | cut -d ':' -f 2 | tr -d 'B')"
   local boot bootloop bootroot
-  local SEDCMDS='s/console=null/console=tty0/'
+  local SEDCMDS='s/console=\(none\|null\)/console=tty0/'
 
   if [ -z "$fsroot" -o "x$bootstart" != "x$partstart" ]
   then
@@ -204,7 +204,7 @@ function boot_enable_console () {
 
   logVariables $LINENO fsroot bootstart bootloop bootroot boot
 
-  if grep -q console=null "$boot/cmdline.txt" ; then
+  if grep -q 'console=\(none\|null\)' "$boot/cmdline.txt" ; then
     info "/boot/cmdline.txt changed to temporarily enable console for autoexpand"
     cp -p "$boot/cmdline.txt" "$boot/cmdline.txt.pishrink-bak"
     sed -i "$boot/cmdline.txt" -e "$SEDCMDS"


### PR DESCRIPTION
If a raspi image is configured to boot really silent, the console may be disabled in /boot/cmdline.txt

In this case the auto-expander may not be called in some cirmunstances. Usually /etc/rc.local which
does expanding, is called by systemd. But systemd may fail to start /etc/rc.local if no console is there.
In the log there is first a
`Aug 13 11:17:01 HOSTNAME kernel: Warning: unable to open an initial console.`
and later:
`Aug 13 11:17:16 HOSTNAME systemd[1]: Starting /etc/rc.local Compatibility...`
`Aug 13 11:17:16 HOSTNAME systemd[740]: Failed at step STDOUT spawning /etc/rc.local: No such device`
`Aug 13 11:17:16 HOSTNAME systemd[1]: Failed to start /etc/rc.local Compatibility.`
As a result the image runs un-expanded.

This pull request fixes this: If a disabled console is detected it will be enabled temporarily until the auto-expander is called.

Since the expander-code in /etc/rc.local must be changed to implement this fix, the
implementation changed how an already auto-expanding image is detected: It does
no longer check md5 sum but compares the code directly.
This makes it even easier to add further features to the auto-expander code.

