### PR TITLE
Support for rc.local AND dietpi/postboot.d hooks for expansion, generic support for mmblkX where X is determined at runtime 

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -167,7 +167,6 @@ exit 0
 EOF1
 
 sed -i "s#BOOTHOOKFILE#$boothook#g; s#RCLOCAL#$rclocal#g" $mountdir$boothook
-cat $mountdir$boothook | grep RCLOCAL
     	#####End no touch zone#####
 			chmod +x "$mountdir$boothook"
     fi

--- a/pishrink.sh
+++ b/pishrink.sh
@@ -78,30 +78,42 @@ function set_autoexpand() {
         return
     fi
 
-    if [[ -f "$mountdir/etc/rc.local" ]] && [[ "$(md5sum "$mountdir/etc/rc.local" | cut -d ' ' -f 1)" != "1c579c7d5b4292fd948399b6ece39009" ]]; then
-      echo "Creating new /etc/rc.local"
-    if [ -f "$mountdir/etc/rc.local" ]; then
-        mv "$mountdir/etc/rc.local" "$mountdir/etc/rc.local.bak"
-    fi
+		if ([[ -f "$mountdir/etc/rc.local" ]] && [[ "$(md5sum "$mountdir/etc/rc.local" | cut -d ' ' -f 1)" != "1c579c7d5b4292fd948399b6ece39009" ]]); then
+			echo "Creating new /etc/rc.local"
+			isok=1
+			rclocal=1
+			boothook=/etc/rc.local
+			if [ -f "$mountdir/etc/rc.local" ]; then
+					mv "$mountdir/etc/rc.local" "$mountdir/etc/rc.local.bak"
+			fi
+		elif [[ -d "$mountdir/var/lib/dietpi/postboot.d" ]]; then
+			echo "Using postboot hooks..."
+			isok=1
+			rclocal=0
+			boothook=/var/lib/dietpi/postboot.d/inflatefs.sh
+		fi
+
+    if [ "$isok" -eq "1" ]; then
 
     #####Do not touch the following lines#####
-cat <<\EOF1 > "$mountdir/etc/rc.local"
+cat <<\EOF1 > "$mountdir$boothook"
 #!/bin/bash
 do_expand_rootfs() {
   ROOT_PART=$(mount | sed -n 's|^/dev/\(.*\) on / .*|\1|p')
+  DEV_PART=$(echo "$ROOT_PART" | cut -f1 -d"p")
 
-  PART_NUM=${ROOT_PART#mmcblk0p}
+  PART_NUM=${ROOT_PART#"${DEV_PART}p"}
   if [ "$PART_NUM" = "$ROOT_PART" ]; then
     echo "$ROOT_PART is not an SD card. Don't know how to expand"
     return 0
   fi
 
   # Get the starting offset of the root partition
-  PART_START=$(parted /dev/mmcblk0 -ms unit s p | grep "^${PART_NUM}" | cut -f 2 -d: | sed 's/[^0-9]//g')
+  PART_START=$(parted /dev/${DEV_PART} -ms unit s p | grep "^${PART_NUM}" | cut -f 2 -d: | sed 's/[^0-9]//g')
   [ "$PART_START" ] || return 1
   # Return value will likely be error for fdisk as it fails to reload the
   # partition table because the root fs is mounted
-  fdisk /dev/mmcblk0 <<EOF
+  fdisk /dev/${DEV_PART} <<EOF
 p
 d
 $PART_NUM
@@ -114,11 +126,11 @@ p
 w
 EOF
 
-cat <<EOF > /etc/rc.local &&
+cat <<EOF > $boothook &&
 #!/bin/sh
 echo "Expanding /dev/$ROOT_PART"
 resize2fs /dev/$ROOT_PART
-rm -f /etc/rc.local; cp -f /etc/rc.local.bak /etc/rc.local; /etc/rc.local
+rm -f $boothook
 
 EOF
 reboot
@@ -140,14 +152,16 @@ sleep 5
 do_expand_rootfs
 echo "ERROR: Expanding failed..."
 sleep 5
-if [[ -f /etc/rc.local.bak ]]; then
-  cp -f /etc/rc.local.bak /etc/rc.local
-  /etc/rc.local
+if [ "$rclocal" -eq "1" ]; then
+	if [[ -f /etc/rc.local.bak ]]; then
+	  cp -f /etc/rc.local.bak /etc/rc.local
+	  /etc/rc.local
+	fi
 fi
 exit 0
 EOF1
-    #####End no touch zone#####
-    chmod +x "$mountdir/etc/rc.local"
+	    #####End no touch zone#####
+			chmod +x "$mountdir$boothook"
     fi
     umount "$mountdir"
 }
@@ -421,3 +435,4 @@ aftersize=$(ls -lh "$img" | cut -d ' ' -f 5)
 logVariables $LINENO aftersize
 
 info "Shrunk $img from $beforesize to $aftersize"
+


### PR DESCRIPTION
This fix enables expansion of dietPi images at next boot (tested with RockPro64 and Dietpi 6.32) through the use of postboot hooks instead of rc.local (however, the original one should stay intact).

Furthermore it moves to a runtime check for the correct /dev/mmcblkXpY numbers which should ideally work with different configurations (even if root is /dev/mmcblk2p1 as in the case of RockPro64 for example)