### PR TITLE
Generate host keys on first boot with option -p

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -309,6 +309,7 @@ if [[ $prep == true ]]; then
   mountdir=$(mktemp -d)
   mount "$loopback" "$mountdir"
   rm -rvf $mountdir/var/cache/apt/archives/* $mountdir/var/lib/dhcpcd5/* $mountdir/var/log/* $mountdir/var/tmp/* $mountdir/tmp/* $mountdir/etc/ssh/*_host_*
+  ln -s /lib/systemd/system/regenerate_ssh_host_keys.service $mountdir/etc/systemd/system/multi-user.target.wants/regenerate_ssh_host_keys.service
   umount "$mountdir"
 fi
 


### PR DESCRIPTION
With option -p host keys are removed and a headless setup is no more possible. With this fix on first boot new host keys are generated.