### PR TITLE
Force locale settings into POSIX

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -221,6 +221,14 @@ if (( EUID != 0 )); then
   exit 3
 fi
 
+# set locale to POSIX(English) temporarily
+# these locale settings only affect the script and its sub processes
+
+export LANGUAGE=POSIX
+export LC_ALL=POSIX
+export LANG=POSIX
+
+
 # check selected compression tool is supported and installed
 if [[ -n $ziptool ]]; then
 	if [[ ! " ${ZIPTOOLS[@]} " =~ $ziptool ]]; then


### PR DESCRIPTION
Hi there.
The script doesn't support systems with non-English locale settings.
In CJK (Chinese, Japanese and Korean) computing,
graphic characters are traditionally classed into fullwidth.
For users who use CJK locales, the colon in the output is '：', rather than ':'.
The script cannot handle these characers, so forcing locale settings into English temporarily can solve this problem.