### PR TITLE
rc.local: get current SD dev from /dev/ and delay a bit to wait for loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,75 +7,20 @@ using multiple cores is supported.
 
 ## Usage ##
 
-```
-Usage: $0 [-adhrspvzZ] imagefile.img [newimagefile.img]
-
-  -s         Don't expand filesystem when image is booted the first time
-  -v         Be verbose
-  -r         Use advanced filesystem repair option if the normal one fails
-  -z         Compress image after shrinking with gzip
-  -Z         Compress image after shrinking with xz
-  -a         Compress image in parallel using multiple cores
-  -p         Remove logs, apt archives, dhcp leases and ssh hostkeys
-  -d         Write debug messages in a debug log file
+```txt
+Usage: pishrink.sh [-adhrspvzZ] file [newfile]
+Shrink and/or compress the given Linux image.
+Options:
+-d         Write debug messages to pishrink.log in the working directory.
+-e n       Add an extra n (default 100) megabytes to the shrunk image.
+-l n       Limit size to expand the rootfs during first boot. See argument of the size2fs command. Ex: "-l 4.5G".
+-p         Purge redudant files (logs, apt archives, dhcp leases...).
+-r         Use advanced filesystem repair option if the normal one fails
+-n         Don't expand filesystem when image is booted the first time
+-z         Compress image after shrinking with gzip
+-Z         Compress image after shrinking with xz
+-a         Compress image in parallel using multiple cores
+-v         Be verbose
 ```
 
 If you specify the `newimagefile.img` parameter, the script will make a copy of `imagefile.img` and work off that. You will need enough space to make a full copy of the image to use that option.
-
-* `-s` prevents automatic filesystem expansion on the images next boot
-* `-v` enables more verbose output
-* `-r` will attempt to repair the filesystem using additional options if the normal repair fails
-* `-z` will compress the image after shrinking using gzip. `.gz` extension will be added to the filename.
-* `-Z` will compress the image after shrinking using xz. `.xz` extension will be added to the filename.
-* `-a` will use option -f9 for pigz and option -T0 for xz and compress in parallel.
-* `-d` will create a logfile `pishrink.log` which may help for problem analysis.
-
-Default options for compressors can be overwritten by defining PISHRINK_GZIP or PSHRINK_XZ environment variables for gzip and xz.
-
-## Prerequisites ##
-
-If you are running PiShrink in VirtualBox you will likely encounter an error if you
-attempt to use VirtualBox's "Shared Folder" feature. You can copy the image you wish to
-shrink on to the VM from a Shared Folder, but shrinking directctly from the Shared Folder
-is know to cause issues.
-
-If using Ubuntu, you will likely see an error about `e2fsck` being out of date and `metadata_csum`. The simplest fix for this is to use Ubuntu 16.10 and up, as it will save you a lot of hassle in the long run.
-
-## Installation ##
-
-```bash
-wget https://raw.githubusercontent.com/Drewsif/PiShrink/master/pishrink.sh
-chmod +x pishrink.sh
-sudo mv pishrink.sh /usr/local/bin
-```
-
-## Example ##
-
-```bash
-[user@localhost PiShrink]$ sudo pishrink.sh pi.img
-e2fsck 1.42.9 (28-Dec-2013)
-Pass 1: Checking inodes, blocks, and sizes
-Pass 2: Checking directory structure
-Pass 3: Checking directory connectivity
-Pass 4: Checking reference counts
-Pass 5: Checking group summary information
-/dev/loop1: 88262/1929536 files (0.2% non-contiguous), 842728/7717632 blocks
-resize2fs 1.42.9 (28-Dec-2013)
-resize2fs 1.42.9 (28-Dec-2013)
-Resizing the filesystem on /dev/loop1 to 773603 (4k) blocks.
-Begin pass 2 (max = 100387)
-Relocating blocks             XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-Begin pass 3 (max = 236)
-Scanning inode table          XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-Begin pass 4 (max = 7348)
-Updating inode references     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-The filesystem on /dev/loop1 is now 773603 blocks long.
-
-Shrunk pi.img from 30G to 3.1G
-```
-
-## Contributing ##
-
-If you find a bug please create an issue for it. If you would like a new feature added, you can create an issue for it but I can't promise that I will get to it.
-
-Pull requests for new features and bug fixes are more than welcome!

--- a/pishrink.sh
+++ b/pishrink.sh
@@ -292,6 +292,8 @@ else
     parttype="logical"
 fi
 loopback="$(losetup -f --show -o "$partstart" "$img")"
+# Wait 3 seconds to ensure loopback is ready.
+sleep 3
 tune2fs_output="$(tune2fs -l "$loopback")"
 rc=$?
 if (( $rc )); then

--- a/pishrink.sh
+++ b/pishrink.sh
@@ -169,7 +169,7 @@ print_usage() {
 	Usage: $0 [-adhrspvzZ] file [newfile]
 	Shrink and/or compress the given Linux image.
 	Options:
-	-d         Write debug messages in a debug log file
+	-d         Write debug messages to pishrink.log in the working directory.
 	-e n       Add an extra n (default 100) megabytes to the shrunk image.
 	-l n       Limit size to expand the rootfs during first boot. See argument of the size2fs command. Ex: "-l 4.5G".
 	-p         Purge redudant files (logs, apt archives, dhcp leases...).

--- a/pishrink.sh
+++ b/pishrink.sh
@@ -363,8 +363,14 @@ if [[ $currentsize -eq $minsize ]]; then
 fi
 
 #Add some free space to the end of the filesystem
-minsize=$(($minsize + $extraspace * 1024**2 / $blocksize))
-logVariables $LINENO minsize
+targetsize=$(($minsize + $extraspace * 1024**2 / $blocksize))
+if [ $targetsize -ge $currentsize ]; then
+	info "Target size ($targetsize) too large, force to current size minus 1"
+	let minsize=$currentsize-1
+else
+	minsize=$targetsize
+fi
+logVariables $LINENO targetsize currentsize minsize
 
 #Shrink filesystem
 info "Shrinking filesystem"


### PR DESCRIPTION
This request modifies rc.local to:
1. Automatically get the current SD block device from /dev/ instead of hardcoding it to mmcblk0, because some board, such as my Odroid C4, name it different (mmcblk1).
2. Added a delay for loopback device to be ready. This is necessary when the image to be shrinked is stored on a slow network share.

Tested on my Raspberry Pi 4, Odroid C4, Orange Pi Zero2 and my Buffalo WXL NAS.
