### PR TITLE
Skip filesystem shrinking without error if it's already right-sized

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -332,36 +332,36 @@ fi
 minsize=$(cut -d ':' -f 2 <<< "$minsize" | tr -d ' ')
 logVariables $LINENO currentsize minsize
 if [[ $currentsize -eq $minsize ]]; then
-  error $LINENO "Image already shrunk to smallest size"
-  exit 11
-fi
+  info "Filesystem already shrunk to smallest size. Skipping filesystem shrinking."
+else
+  #Add some free space to the end of the filesystem
+  extra_space=$(($currentsize - $minsize))
+  logVariables $LINENO extra_space
+  for space in 5000 1000 100; do
+    if [[ $extra_space -gt $space ]]; then
+      minsize=$(($minsize + $space))
+      break
+    fi
+  done
+  logVariables $LINENO minsize
 
-#Add some free space to the end of the filesystem
-extra_space=$(($currentsize - $minsize))
-logVariables $LINENO extra_space
-for space in 5000 1000 100; do
-  if [[ $extra_space -gt $space ]]; then
-    minsize=$(($minsize + $space))
-    break
+  #Shrink filesystem
+  info "Shrinking filesystem"
+  resize2fs -p "$loopback" $minsize
+  rc=$?
+  if (( $rc )); then
+    error $LINENO "resize2fs failed with rc $rc"
+    mount "$loopback" "$mountdir"
+    mv "$mountdir/etc/rc.local.bak" "$mountdir/etc/rc.local"
+    umount "$mountdir"
+    losetup -d "$loopback"
+    exit 12
   fi
-done
-logVariables $LINENO minsize
-
-#Shrink filesystem
-info "Shrinking filesystem"
-resize2fs -p "$loopback" $minsize
-rc=$?
-if (( $rc )); then
-  error $LINENO "resize2fs failed with rc $rc"
-  mount "$loopback" "$mountdir"
-  mv "$mountdir/etc/rc.local.bak" "$mountdir/etc/rc.local"
-  umount "$mountdir"
-  losetup -d "$loopback"
-  exit 12
+  sleep 1
 fi
-sleep 1
 
 #Shrink partition
+info "Shrinking partition"
 partnewsize=$(($minsize * $blocksize))
 newpartend=$(($partstart + $partnewsize))
 logVariables $LINENO partnewsize newpartend


### PR DESCRIPTION
I had a case handed to me by a user of your script where I observed the following:

The image was 60 GB large but only had a 0.5 GB fat32 partition and an 5.81 GB ext4 partition. Maybe the image was not expanded after being moved before, I don't know. The `resize2fs` estimate was that the filesystem could not be shrunk so the whole script errored out with error 11.

The filesystem already being right-sized is not inherently an unrecoverable error. We can continue the process anyway and proceed with shrinking partitions and truncating the file. That's all that my change does, replaces the error by a branch and changes some log messages to indicate the behaviour.