### PR TITLE
Fix issue #168: regenerate ssh host keys

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -317,6 +317,7 @@ if [[ $prep == true ]]; then
   mountdir=$(mktemp -d)
   mount "$loopback" "$mountdir"
   rm -rvf $mountdir/var/cache/apt/archives/* $mountdir/var/lib/dhcpcd5/* $mountdir/var/log/* $mountdir/var/tmp/* $mountdir/tmp/* $mountdir/etc/ssh/*_host_*
+  ln -sf /lib/systemd/system/regenerate_ssh_host_keys.service $mountdir/etc/systemd/system/multi-user.target.wants/regenerate_ssh_host_keys.service
   umount "$mountdir"
 fi
 


### PR DESCRIPTION
Enable regenerate_ssh_host_keys.service after deleting host-keys.

Issuing #168 