### PR TITLE
Fixed ssh host keys not regenerating

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -331,7 +331,7 @@ if [[ $prep == true ]]; then
           dd if=/dev/hwrng of=/dev/urandom count=1 bs=4096 status=none
         fi
         rm -f $mountdir/etc/ssh/ssh_host_*_key*
-        ssh-keygen -A -f $mountdir/etc/ssh > /dev/null
+        ssh-keygen -A -f $mountdir > /dev/null
       fi
     fi
   #check if dropbear is enabled

--- a/pishrink.sh
+++ b/pishrink.sh
@@ -331,6 +331,7 @@ if [[ $prep == true ]]; then
           dd if=/dev/hwrng of=/dev/urandom count=1 bs=4096 status=none
         fi
         rm -f $mountdir/etc/ssh/ssh_host_*_key*
+        info "regenerating ssh host keys"
         ssh-keygen -A -f $mountdir > /dev/null
       fi
     fi
@@ -341,9 +342,10 @@ if [[ $prep == true ]]; then
       info "WARNING: could not locate dropbearkey command, keeping old keys"
     else
       rm -f $mountdir/etc/dropbear/dropbear_*_host_key
-      dropbearkey -t rsa -f $mountdir/etc/dropbear/dropbear_rsa_host_key
-      dropbearkey -t ecdsa -f $mountdir/etc/dropbear/dropbear_ecdsa_host_key
-      dropbearkey -t ed25519 -f $mountdir/etc/dropbear/dropbear_ed25519_host_key
+      info "regenerating dropbear keys"
+      dropbearkey -t rsa -f $mountdir/etc/dropbear/dropbear_rsa_host_key > /dev/null
+      dropbearkey -t ecdsa -f $mountdir/etc/dropbear/dropbear_ecdsa_host_key > /dev/null
+      dropbearkey -t ed25519 -f $mountdir/etc/dropbear/dropbear_ed25519_host_key > /dev/null 
     fi
   fi
   umount "$mountdir"

--- a/pishrink.sh
+++ b/pishrink.sh
@@ -316,7 +316,36 @@ if [[ $prep == true ]]; then
   info "Syspreping: Removing logs, apt archives, dhcp leases and ssh hostkeys"
   mountdir=$(mktemp -d)
   mount "$loopback" "$mountdir"
-  rm -rvf $mountdir/var/cache/apt/archives/* $mountdir/var/lib/dhcpcd5/* $mountdir/var/log/* $mountdir/var/tmp/* $mountdir/tmp/* $mountdir/etc/ssh/*_host_*
+  rm -rvf $mountdir/var/cache/apt/archives/* $mountdir/var/lib/dhcpcd5/* $mountdir/var/log/* $mountdir/var/tmp/* $mountdir/tmp/*
+  #check if openssh is enabled
+  if [[ -f "$mountdir/etc/systemd/system/multi-user.target.wants/ssh.service" ]]; then
+    if [[ -f "$mountdir/lib/systemd/system/regenerate_ssh_host_keys.service" ]] && [[ -d "$mountdir/etc/systemd/system/multi-user.target.wants" ]]; then
+      ln -s $mountdir/lib/systemd/system/regenerate_ssh_host_keys.service $mountdir/etc/systemd/system/multi-user.target.wants/regenerate_ssh_host_keys.service
+      info "host keys on disk remain but should regenerate on first boot."
+    else
+      #key regeneration relies on using the host to regenerate the keys
+      if ! command -v ssh-keygen &> /dev/null; then
+        info "WARNING: could not locate ssh-keygen command, keeping old keys"
+      else
+        if [ -c /dev/hwrng ]; then
+          dd if=/dev/hwrng of=/dev/urandom count=1 bs=4096 status=none
+        fi
+        rm -f $mountdir/etc/ssh/ssh_host_*_key*
+        ssh-keygen -A -f $mountdir/etc/ssh > /dev/null
+      fi
+    fi
+  #check if dropbear is enabled
+  elif [[ -f "$mountdir/etc/init.d/dropbear" ]]; then
+    #key regeneration relies on using the host to regenerate the keys
+    if ! command -v dropbearkey &> /dev/null; then
+      info "WARNING: could not locate dropbearkey command, keeping old keys"
+    else
+      rm -f $mountdir/etc/dropbear/dropbear_*_host_key
+      dropbearkey -t rsa -f $mountdir/etc/dropbear/dropbear_rsa_host_key
+      dropbearkey -t ecdsa -f $mountdir/etc/dropbear/dropbear_ecdsa_host_key
+      dropbearkey -t ed25519 -f $mountdir/etc/dropbear/dropbear_ed25519_host_key
+    fi
+  fi
   umount "$mountdir"
 fi
 


### PR DESCRIPTION
When using the -p option, the ssh host keys would be deleted, but not regenerated, rendering ssh unusable. fixes #168 but relies on the host system to regenerate keys on non-Raspbian distros