### PR TITLE
Use /usr/bin/env bash for portability

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Project: PiShrink
 # Description: PiShrink is a bash script that automatically shrink a pi image that will then resize to the max size of the SD card on boot.


### PR DESCRIPTION
Updated the shebang from /bin/bash to /usr/bin/env bash to enhance script portability. This ensures compatibility with systems where bash is not located in /bin, such as NixOS, where the bash interpreter is managed via the Nix store and resides in non-standard locations.

This shouldn't have any downsides, as /usr/bin/env searches PATH for the binary.

https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash/21613044#21613044